### PR TITLE
fix(IDR): turn IDR model from joint to sequential PD

### DIFF
--- a/03-indirect_response.jl
+++ b/03-indirect_response.jl
@@ -167,8 +167,7 @@ iparams_pd = (
 
 pd_fit = fit(pd_model, pop_pd, iparams_pd, FOCE())
 
-pkpd_inspect = inspect(pkpd_fit)
+pd_inspect = inspect(pd_fit)
 
-# Plotting a GoF for each type of observation separately
-goodness_of_fit(pkpd_inspect; ols=false, observations=[:dv])
-goodness_of_fit(pkpd_inspect; ols=false, observations=[:resp])
+# Plotting a GoF
+goodness_of_fit(pd_inspect; ols=false)

--- a/03-indirect_response.jl
+++ b/03-indirect_response.jl
@@ -15,52 +15,51 @@ pkdata = dataset("inf_sd_5_idr")
 # `observations` keyword argument
 # PD pop is a little bit further below
 pop_pk = read_pumas(
-    pkdata;
-    observations=[:dv],
+  pkdata;
+  observations=[:dv]
 )
 
 # This is a PK model
 pk_model = @model begin
-    @param begin
-        tvcl ∈ RealDomain(; lower=0)
-        tvvc ∈ RealDomain(; lower=0)
-        tvq ∈ RealDomain(; lower=0)
-        tvvp ∈ RealDomain(; lower=0)
-        Ω ∈ PDiagDomain(4)
-        σ_prop ∈ RealDomain(; lower=0)
-    end
+  @param begin
+    tvcl ∈ RealDomain(; lower=0)
+    tvvc ∈ RealDomain(; lower=0)
+    tvq ∈ RealDomain(; lower=0)
+    tvvp ∈ RealDomain(; lower=0)
+    Ω ∈ PDiagDomain(4)
+    σ_prop ∈ RealDomain(; lower=0)
+  end
 
-    @random begin
-        η ~ MvNormal(Ω)
-    end
+  @random begin
+    η ~ MvNormal(Ω)
+  end
 
-    @pre begin
-        CL = tvcl * exp(η[1])
-        Vc = tvvc * exp(η[2])
-        Q = tvq * exp(η[3])
-        Vp = tvvp * exp(η[4])
-    end
+  @pre begin
+    CL = tvcl * exp(η[1])
+    Vc = tvvc * exp(η[2])
+    Q = tvq * exp(η[3])
+    Vp = tvvp * exp(η[4])
+  end
 
-    @dynamics begin
-        Central' = -(CL / Vc) * Central + (Q / Vp) * Peripheral - (Q / Vc) * Central
-        Peripheral' = (Q / Vc) * Central - (Q / Vp) * Peripheral
-    end
+  @dynamics begin
+    Central' = -(CL / Vc) * Central + (Q / Vp) * Peripheral - (Q / Vc) * Central
+    Peripheral' = (Q / Vc) * Central - (Q / Vp) * Peripheral
+  end
 
-    # Both PK and PD observations
-    @derived begin
-        conc := @. Central / Vc
-        dv ~ @. Normal(conc, conc * σ_prop)
-    end
+  @derived begin
+    conc := @. Central / Vc
+    dv ~ @. Normal(conc, conc * σ_prop)
+  end
 end
 
 # PK initial parameter values
 iparams_pk = (
-    tvcl=1.5,
-    tvvc=25.0,
-    tvq=5.0,
-    tvvp=150.0,
-    Ω=Diagonal([0.05, 0.05, 0.05, 0.05]),
-    σ_prop=0.15,
+  tvcl=1.5,
+  tvvc=25.0,
+  tvq=5.0,
+  tvvp=150.0,
+  Ω=Diagonal([0.05, 0.05, 0.05, 0.05]),
+  σ_prop=0.15,
 )
 
 # Now we fit the PK model
@@ -87,82 +86,81 @@ rename!(
 # PD Population with the
 # PK individual parameters as covariates
 pop_pd = read_pumas(
-    pkdata;
-    observations=[:resp],
-    covariates=[:iCL, :iVc, :iQ, :iVp, :BSL]
+  pkdata;
+  observations=[:resp],
+  covariates=[:iCL, :iVc, :iQ, :iVp, :BSL]
 )
 
 # This is a sequential PD model
 # We are using the PK individual parameters
 # as covariates
 pd_model = @model begin
-    @param begin
-        tvturn ∈ RealDomain(; lower=0)
-        tvebase ∈ RealDomain(; lower=0)
-        tvec50 ∈ RealDomain(; lower=0)
-        Ω ∈ PDiagDomain(1)
-        σ_add ∈ RealDomain(; lower=0)
-    end
+  @param begin
+    tvturn ∈ RealDomain(; lower=0)
+    tvebase ∈ RealDomain(; lower=0)
+    tvec50 ∈ RealDomain(; lower=0)
+    Ω ∈ PDiagDomain(1)
+    σ_add ∈ RealDomain(; lower=0)
+  end
 
-    @random begin
-        η ~ MvNormal(Ω)
-    end
+  @random begin
+    η ~ MvNormal(Ω)
+  end
 
-    @covariates iCL iVc iQ iVp BSL
+  @covariates iCL iVc iQ iVp BSL
 
-    @pre begin
-        # PK individual parameters
-        CL = iCL
-        Vc = iVc
-        Q  = iQ
-        Vp = iVp
+  @pre begin
+    # PK individual parameters
+    CL = iCL
+    Vc = iVc
+    Q = iQ
+    Vp = iVp
 
-        # PD individual parameters
-        ebase = tvebase * exp(η[1])
-        ec50 = tvec50
-        emax = 1
-        turn = tvturn
-        kout = 1 / turn
-        kin0 = ebase * kout
-    end
+    # PD individual parameters
+    ebase = tvebase * exp(η[1])
+    ec50 = tvec50
+    emax = 1
+    turn = tvturn
+    kout = 1 / turn
+    kin0 = ebase * kout
+  end
 
-    # This is a new block
-    # It has the purpose to define, for each subject,
-    # the compartments initial values
-    # These can be either a fixed value or a parameter-based value
-    @init begin
-        Resp = ebase
-    end
+  # This is a new block
+  # It has the purpose to define, for each subject,
+  # the compartments initial values
+  # These can be either a fixed value or a parameter-based value
+  @init begin
+    Resp = ebase
+  end
 
-    # This is a new block
-    # It is used to define aliases for any operation based on parameters or values
-    # to be used in the `@dynamics` and `@derived` blocks in order to avoid too much cluttering
-    @vars begin
-        conc := Central / Vc
-        edrug := emax * conc / (ec50 + conc)
-        kin := kin0 * (1 - edrug)
-    end
+  # This is a new block
+  # It is used to define aliases for any operation based on parameters or values
+  # to be used in the `@dynamics` and `@derived` blocks in order to avoid too much cluttering
+  @vars begin
+    conc := Central / Vc
+    edrug := emax * conc / (ec50 + conc)
+    kin := kin0 * (1 - edrug)
+  end
 
-    # Both PK and PD ODEs
-    @dynamics begin
-        Central' = -(CL / Vc) * Central + (Q / Vp) * Peripheral - (Q / Vc) * Central
-        Peripheral' = (Q / Vc) * Central - (Q / Vp) * Peripheral
-        Resp' = kin - kout * Resp
-    end
+  # Both PK and PD ODEs
+  @dynamics begin
+    Central' = -(CL / Vc) * Central + (Q / Vp) * Peripheral - (Q / Vc) * Central
+    Peripheral' = (Q / Vc) * Central - (Q / Vp) * Peripheral
+    Resp' = kin - kout * Resp
+  end
 
-    # Both PK and PD observations
-    @derived begin
-        resp ~ @. Normal(Resp, σ_add)
-    end
+  @derived begin
+    resp ~ @. Normal(Resp, σ_add)
+  end
 end
 
 # PD initial parameter values
 iparams_pd = (
-    tvturn=10,
-    tvebase=10,
-    tvec50=0.3,
-    Ω=Diagonal([0.05]),
-    σ_add=0.5,
+  tvturn=10,
+  tvebase=10,
+  tvec50=0.3,
+  Ω=Diagonal([0.05]),
+  σ_add=0.5,
 )
 
 pd_fit = fit(pd_model, pop_pd, iparams_pd, FOCE())

--- a/docs/instructors.md
+++ b/docs/instructors.md
@@ -87,9 +87,13 @@ Finally, we'll move into indirect response models, and also into PD models.
 Proceed to the `03-indirect_response.jl` file.
 Here the `pkdata` has two columns of observations: the `:dv` and the `:resp` columns.
 Explain that the `:dv` is for the PK measurements and the `:resp` for the PD measurements.
-It is important to emphasize that this wide column format is the only difference in data format that Pumas diverges from NM-TRAN.
-Now, walkthrough the model definition.
-Make sure that learners understand the different PK and PD components in the `@param`,
+This is a sequential PD model.
+That means, that we'll fit first the PK part of the model.
+The PK model is not different from the models that learners have experienced in the pre-requisites of this workshop.
+Then, we proceed by extracting the PK individual parameters from the fit and merging to the original data.
+We read the updated data into a `Population` and pass the PK individual parameters as covariates in the `read_pumas` function.
+Now, walkthrough the PD model definition.
+Make sure that learners understand the different PD components in the `@param`,
 `@random`, `@pre` and `@derived` block.
 There are two new model blocks that learners might not have been exposed yet: `@init` and `@vars`.
 The `@init` block has the purpose of defining initial values for the subjects compartments.
@@ -99,7 +103,7 @@ The `@vars` block is used to define aliases that can be used in the `@dynamics` 
 These aliases can use any variable defined in the `@pre` and `@covariates` block and any Julia variable or value,
 user-defined or not.
 This is a good way to declutter your ODE equations in the `@dynamics` block.
-Finally, showcase that you can have a GoF plot for each observation separated.
+Finally, showcase a GoF plot for the PD inspect result.
 The important part here is to showcase the flexibility and ease-of-use of Pumas modeling syntax to define complex models without overloading the user.
 
 ## Get in touch


### PR DESCRIPTION
As suggested by Joel and also through my brief experiences with PKPD modellers, users rarely do joint PKPD modeling.
Instead, they do a sequential workflow.
First, they fit the PK part.
Once they are satisfied with PK results they move forward to the PD part by adding the PK icoefs as covariates into the PD model.